### PR TITLE
pkg-config support for nufxlib

### DIFF
--- a/nufxlib/.gitignore
+++ b/nufxlib/.gitignore
@@ -3,6 +3,7 @@ Makefile
 config.h
 config.log
 config.status
+nufxlib.pc
 
 # generated binaries
 libnufx.a

--- a/nufxlib/Makefile.in
+++ b/nufxlib/Makefile.in
@@ -60,14 +60,16 @@ all: $(PRODUCT) samples
 install: $(STATIC_PRODUCT)
 	$(srcdir)/mkinstalldirs $(libdir)
 	$(INSTALL_DATA) $(STATIC_PRODUCT) $(libdir)
-	$(srcdir)/mkinstalldirs $(includedir)
+	$(srcdir)/mkinstalldirs $(includedir) $(libdir)/pkgconfig
 	$(INSTALL_DATA) NufxLib.h $(includedir)
+	$(INSTALL_DATA) nufxlib.pc $(libdir)/pkgconfig
 
 install-shared: $(SHARED_PRODUCT)
 	$(srcdir)/mkinstalldirs $(libdir)
 	$(INSTALL_DATA) $(SHARED_PRODUCT) $(libdir)
-	$(srcdir)/mkinstalldirs $(includedir)
+	$(srcdir)/mkinstalldirs $(includedir) $(libdir)/pkgconfig
 	$(INSTALL_DATA) NufxLib.h $(includedir)
+	$(INSTALL_DATA) nufxlib.pc $(libdir)/pkgconfig
 
 samples:: $(STATIC_PRODUCT)
 	@echo "Building samples..."

--- a/nufxlib/configure
+++ b/nufxlib/configure
@@ -626,6 +626,7 @@ BUILD_FLAGS
 EGREP
 GREP
 CPP
+NUFX_VERSION
 RANLIB
 SET_MAKE
 INSTALL_DATA
@@ -3273,6 +3274,10 @@ else
 fi
 
 
+NUFX_VERSION=3.1.0
+
+
+
 
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
@@ -4220,7 +4225,7 @@ if test "${enable_dmalloc+set}" = set; then :
 fi
 
 
-ac_config_files="$ac_config_files Makefile samples/Makefile"
+ac_config_files="$ac_config_files Makefile samples/Makefile nufxlib.pc"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -4915,6 +4920,7 @@ do
     "config.h") CONFIG_HEADERS="$CONFIG_HEADERS config.h" ;;
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
     "samples/Makefile") CONFIG_FILES="$CONFIG_FILES samples/Makefile" ;;
+    "nufxlib.pc") CONFIG_FILES="$CONFIG_FILES nufxlib.pc" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac

--- a/nufxlib/configure.in
+++ b/nufxlib/configure.in
@@ -16,6 +16,10 @@ AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 AC_PROG_RANLIB
 
+NUFX_VERSION=3.1.0
+AC_SUBST(NUFX_VERSION)
+
+
 dnl Checks for header files.
 AC_CHECK_HEADERS(fcntl.h malloc.h stdlib.h sys/stat.h sys/time.h sys/types.h \
     sys/utime.h unistd.h utime.h)
@@ -215,4 +219,4 @@ AC_ARG_ENABLE(dmalloc, [  --enable-dmalloc        do dmalloc stuff],
     [ echo "--- enabling dmalloc";
     LIBS="$LIBS -L/usr/local/lib -ldmalloc"; AC_DEFINE(USE_DMALLOC, [], [Define if we want to use the dmalloc library (also need -l in Makefile).]) ])
 
-AC_OUTPUT(Makefile samples/Makefile)
+AC_OUTPUT(Makefile samples/Makefile nufxlib.pc)

--- a/nufxlib/nufxlib.pc.in
+++ b/nufxlib/nufxlib.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: nufxlib
+Description: NuFX archive manipulation library.
+Version: @NUFX_VERSION@
+Libs: -L${libdir} -lnufx @LIBS@
+Cflags: -I${includedir}


### PR DESCRIPTION
Will generate nufxlib.pc and install to the pkgconfig directory for use with the oft-used pkg-config utility.