### PR TITLE
configure: Fix C99 compatibility issue

### DIFF
--- a/nufxlib/configure
+++ b/nufxlib/configure
@@ -4033,7 +4033,7 @@ else
             int count;
             char buf[8];
             count = sprintf(buf, "123");    /* should return three */
-            exit(count != 3);
+            return count != 3;
         }
 
 _ACEOF

--- a/nufxlib/configure.in
+++ b/nufxlib/configure.in
@@ -134,7 +134,7 @@ AC_CACHE_VAL(nufxlib_cv_sprintf_returns_int, [
             int count;
             char buf[8];
             count = sprintf(buf, "123");    /* should return three */
-            exit(count != 3);
+            return count != 3;
         }
     ],
     [nufxlib_cv_sprintf_returns_int=yes], [nufxlib_cv_sprintf_returns_int=no],


### PR DESCRIPTION
Avoid calling the undeclared exit function.  This avoids a check failure with a future compiler that does not support implicit function declarations.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
